### PR TITLE
Fix errors reported by Dialyzer

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,7 @@ defmodule PhxLocalizedRoutes.MixProject do
       aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: compilers(Mix.env()),
+      dialyzer: dialyzer(),
       # Docs
       name: @name,
       description: description(),
@@ -48,6 +49,8 @@ defmodule PhxLocalizedRoutes.MixProject do
 
   defp compilers(:test), do: [:gettext] ++ Mix.compilers()
   defp compilers(_), do: Mix.compilers()
+
+  defp dialyzer, do: [plt_add_apps: [:mix, :gettext, :phoenix_live_view]]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/localized_routes_test.exs
+++ b/test/localized_routes_test.exs
@@ -40,6 +40,7 @@ defmodule PhxLocalizedRoutesTest do
   alias PhxLocalizedRoutes.Exceptions.MissingRootSlugError
   alias PhxLocalizedRoutes.Private, as: P
   alias PhxLocalizedRoutes.Scope
+  alias PhxLocalizedRoutes.Config
 
   alias My.Assigns
 
@@ -166,25 +167,25 @@ defmodule PhxLocalizedRoutesTest do
   describe "test private functions" do
     test "validate opts raises on assign keys mismatch" do
       assert_raise AssignsMismatchError, fn ->
-        P.validate_config!(%{
+        P.validate_config!(%Config{
           scopes: %{
             nil => %{
               scope_prefix: "/",
-              assign: %{key1: 1, key2: 2},
-              scopes: %{"foo" => %{assign: %{key1: 1}}}
-            }
+              assign: %{key1: 1, key2: 2}
+            },
+            "foo" => %{assign: %{key1: 1}}
           }
         })
       end
     end
 
     test "validate opts does not raise when no assigns" do
-      P.validate_config!(%{
+      P.validate_config!(%Config{
         scopes: %{
           nil => %{
-            scope_prefix: "/",
-            scopes: %{"foo" => %{}}
-          }
+            scope_prefix: "/"
+          },
+          "foo" => %{}
         }
       })
     end
@@ -192,13 +193,13 @@ defmodule PhxLocalizedRoutesTest do
     test "validate opts does not raise when assign keys match" do
       matching_assign = %{key1: 1, key2: 2}
 
-      P.validate_config!(%{
+      P.validate_config!(%Config{
         scopes: %{
           nil => %{
             scope_prefix: "/",
-            assign: matching_assign,
-            scopes: %{"foo" => %{assign: matching_assign}}
-          }
+            assign: matching_assign
+          },
+          "foo" => %{assign: matching_assign}
         }
       })
     end
@@ -213,24 +214,24 @@ defmodule PhxLocalizedRoutesTest do
 
     test "validate opts raises when gettext_module is set but no locale in assign" do
       assert_raise MissingLocaleAssignError, fn ->
-        P.validate_config!(%{
+        P.validate_config!(%Config{
           gettext_module: MyGettextModule,
-          scopes: %{"foo" => %{assign: %{key1: 1}}}
+          scopes: %{nil => %{scope_prefix: "/", assign: %{key1: 1}}}
         })
       end
     end
 
     test "validate opts does not raise when gettext_module is set and locale in assign" do
-      P.validate_config!(%{
+      P.validate_config!(%Config{
         gettext_module: MyGettextModule,
-        scopes: %{"foo" => %{scope_prefix: "/", assign: %{locale: "de"}}}
+        scopes: %{nil => %{scope_prefix: "/", assign: %{locale: "de"}}}
       })
     end
 
     test "validate opts does not raise when gettext_module is set to nil" do
-      P.validate_config!(%{
+      P.validate_config!(%Config{
         gettext_module: nil,
-        scopes: %{"foo" => %{scope_prefix: "/", assign: %{locale: "de"}}}
+        scopes: %{nil => %{scope_prefix: "/", assign: %{locale: "de"}}}
       })
     end
 


### PR DESCRIPTION
This fixes the errors show after running`mix dialyzer` by adding :gettext and :mix to the PLT. It also fixes a few specs with 0 errors as a result.

**Before**
```
Total errors: 5, Skipped: 0, Unnecessary Skips: 0

lib/localized_routes.ex:375:unknown_function
Function Mix.Project.get!/0 does not exist.
________________________________________________________________________________
lib/localized_routes/live_helpers.ex:26:unknown_function
Function Phoenix.LiveView.assign/2 does not exist.
________________________________________________________________________________
lib/localized_routes/router.ex:214:unknown_function
Function Gettext.put_locale/2 does not exist.
________________________________________________________________________________
lib/localized_routes/router.ex:229:unknown_function
Function Gettext.dgettext/3 does not exist.
________________________________________________________________________________
lib/localized_routes.ex:108:no_return
Function MACRO-__using__/2 has no local return.
```

**After**
```
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
```