### PR TITLE
Improve test stability

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,19 +14,19 @@ permissions:
   contents: write
 
 jobs:
-  example_matrix:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: [1.13.4]
-        otp: [24.3.4]
+        elixir: [1.13.4, 1.14.2]
+        otp: [24.3.4, 25.2.0]
         
     name: Build and test
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }} # Define the elixir version [required]
         otp-version: ${{ matrix.otp }} # Define the OTP version [required]
@@ -73,8 +73,20 @@ jobs:
     - name: Build docs
       uses: lee-dohm/generate-elixir-docs@v1
 
-    - name: Publish to Pages
-      uses: peaceiris/actions-gh-pages@v3
+    - name: upload artifact
+      uses: actions/upload-artifact@v2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./doc
+        name: public${{ matrix.build }}
+        path: public
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Publish to Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc

--- a/test/localized_routes_test.exs
+++ b/test/localized_routes_test.exs
@@ -1,5 +1,5 @@
 defmodule PhxLocalizedRoutesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias PhxLocalizedRoutes.Fixtures, as: F
   alias PhxLocalizedRoutes.Private, as: P
@@ -7,6 +7,10 @@ defmodule PhxLocalizedRoutesTest do
   require Logger
 
   @scopes_flat F.scopes_flat()
+
+  setup do
+    Logger.flush()
+  end
 
   describe "pre-compile function print_compile_header/3" do
     test "does not print a warning when no Gettext module is set" do


### PR DESCRIPTION
Do not async run some tests which use CaptureLog, as even with flush they might fail on CI.