### PR TITLE
Improve Elixir 1.14 compatibility

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -28,7 +28,7 @@ modules / files need changes.
 no code changes in controllers and (live)views necessary.
 
 ```elixir
-# file: lib/example_web/example_web.ex
+# file: lib/example_web.ex
 
 # in controller
 -  alias ExampleWeb.Router.Helpers, as: Routes

--- a/lib/localized_routes.ex
+++ b/lib/localized_routes.ex
@@ -69,7 +69,7 @@ defmodule PhxLocalizedRoutes.Private do
 
   @spec compile_actions(opts, caller, env) :: Macro.output()
   def compile_actions(opts, caller, env) do
-    print_compile_header(caller.module, in_compilers?(:gettext), opts)
+    print_compile_header(System.version(), caller.module, in_compilers?(:gettext), opts)
 
     if in_deps?(:phoenix_live_view),
       do: create_live_helper_module(caller.module, env)
@@ -147,7 +147,7 @@ defmodule PhxLocalizedRoutes.Private do
   @spec in_compilers?(app :: atom) :: boolean
   def in_compilers?(app) do
     Mix.Project.get!().project()
-    |> Access.get(:compilers)
+    |> Access.get(:compilers, [])
     |> Enum.member?(app)
   end
 
@@ -160,12 +160,15 @@ defmodule PhxLocalizedRoutes.Private do
   end
 
   @spec print_compile_header(
+          sys_version :: String.t(),
           caller_module :: module,
           gettext_in_compilers? :: boolean,
           opts :: opts
         ) :: :ok
-  def print_compile_header(caller_module, gettext_in_compilers?, config_mod) do
-    unless is_nil(config_mod[:gettext_module]) or gettext_in_compilers? do
+  def print_compile_header(sys_version, caller_module, gettext_in_compilers?, config_mod) do
+    unless Version.match?(sys_version, ">= 1.14.0") or
+             is_nil(config_mod[:gettext_module]) or
+             gettext_in_compilers? do
       router_module =
         caller_module
         |> Module.split()

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PhxLocalizedRoutes.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/BartOtten/phoenix_localized_routes"
-  @version "0.1.2"
+  @version "0.1.3"
   @name "Phoenix Localized Routes"
 
   def project do

--- a/test/localized_routes_test.exs
+++ b/test/localized_routes_test.exs
@@ -17,7 +17,7 @@ defmodule PhxLocalizedRoutesTest do
       Logger.flush()
 
       assert ExUnit.CaptureLog.capture_log(fn ->
-               P.print_compile_header(TestRouter, false, %{
+               P.print_compile_header("1.13.2", TestRouter, false, %{
                  scopes: @scopes_flat
                })
              end) == ""
@@ -27,7 +27,7 @@ defmodule PhxLocalizedRoutesTest do
       Logger.flush()
 
       assert ExUnit.CaptureLog.capture_log(fn ->
-               P.print_compile_header(TestRouter, true, %{
+               P.print_compile_header("1.13.2", TestRouter, true, %{
                  gettext_module: MyAppWeb.Gettext,
                  scopes: @scopes_flat
                })
@@ -38,12 +38,23 @@ defmodule PhxLocalizedRoutesTest do
       Logger.flush()
 
       assert ExUnit.CaptureLog.capture_log(fn ->
-               P.print_compile_header(TestRouter, false, %{
+               P.print_compile_header("1.13.2", TestRouter, false, %{
                  gettext_module: MyAppWeb.Gettext,
                  scopes: @scopes_flat
                })
              end) =~
                "When route translations are updated, run `mix compile --force TestRouter.Router`"
+    end
+
+    test "does not print a warning when Elixir >= 1.14 is used" do
+      Logger.flush()
+
+      assert ExUnit.CaptureLog.capture_log(fn ->
+               P.print_compile_header("1.14.2", TestRouter, false, %{
+                 gettext_module: MyAppWeb.Gettext,
+                 scopes: @scopes_flat
+               })
+             end) =~ ""
     end
   end
 end


### PR DESCRIPTION
The compilers option in Mix is now optional and therefor can be nil instead of a list. Also, Elixir >= 1.14 does not need the gettext compiler specified.